### PR TITLE
Add aria attributes for Ember Modal Dialog

### DIFF
--- a/types/ember-modal-dialog/modal-dialog.d.ts
+++ b/types/ember-modal-dialog/modal-dialog.d.ts
@@ -151,6 +151,20 @@ export interface ModalDialogArgs {
      * @memberof ModalDialogArgs
      */
     wrapperClassNames?: string;
+    /**
+     * Can be used to control what element acts as an aria label for this modal
+     *
+     * @type {string}
+     * @memberof ModalDialogArgs
+     */
+     'aria-labelledby'?: string;
+    /**
+     * Can be used to control what element acts as an aria description for this modal
+     *
+     * @type {string}
+     * @memberof ModalDialogArgs
+     */
+     'aria-describedby'?: string;
 }
 
 export class ModalDialog extends Component<BaseGlimmerSignature<ModalDialogArgs>> {}


### PR DESCRIPTION
`aria-labelledby` and `aria-describedby` are both valid arguments for `modal-dialog`, this adds them.