### PR TITLE
animated-each yields the item and the item's index

### DIFF
--- a/types/ember-animated/animated-each.d.ts
+++ b/types/ember-animated/animated-each.d.ts
@@ -41,7 +41,7 @@ export interface AnimatedEachArgs<T> {
 export interface AnimatedEachSignature<T> {
   Args: AnimatedEachArgs<T>;
   Yields: {
-    default: [T];
+    default: [T, number];
     else: [];
   };
 }


### PR DESCRIPTION
`animated-each` yields both the item and the item's index

[source][]:

```
{{#each this.renderedChildren key="id" as |child|}}
  <-EaListElement @child={{child}} @elementToChild={{this._elementToChild}}>
    {{~yield child.value child.index~}}
  </-EaListElement>
{{else}}
  {{~yield to="inverse"~}}
{{/each}}
```

[source]: https://github.com/ember-animation/ember-animated/blob/bbd70986e92686cb37e49f49cbc87ed01308ad41/addon/templates/components/animated-each.hbs#L3