### PR TITLE
Add some peerDeps to help support pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,17 @@
         "typescript": "^4.8.4",
         "validated-changeset": "^1.3.2"
     },
+    "peerDependencies": {
+        "ember-animated": "^1.0.0",
+        "ember-basic-dropdown": "^6.0.1",
+        "ember-concurrency": "^2.0.3",
+        "ember-concurrency-async": "^1.0.0",
+        "ember-concurrency-ts": "^0.3.0",
+        "ember-intl": "^5.7.2",
+        "ember-modifier": "^3.2.7",
+        "ember-power-select": "^5.0.0",
+        "ember-source": "^3.28.0 | ^4.0.0"
+    },
     "publishConfig": {
         "access": "public"
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,33 @@
         "ember-intl": "^5.7.2",
         "ember-modifier": "^3.2.7",
         "ember-power-select": "^5.0.0",
-        "ember-source": "^3.28.0 | ^4.0.0"
+        "ember-source": "^3.28.0 | ^4.0.0 | ^5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "ember-animated": {
+            "optional": true
+        },
+        "ember-basic-dropdown": {
+            "optional": true
+        },
+        "ember-concurrency": {
+            "optional": true
+        },
+        "ember-concurrency-async": {
+            "optional": true
+        },
+        "ember-concurrency-ts": {
+            "optional": true
+        },
+        "ember-intl": {
+            "optional": true
+        },
+        "ember-modifier": {
+            "optional": true
+        },
+        "ember-power-select": {
+            "optional": true
+        }
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
This is not necessarily an exhaustive list, but anything we import from needs to be either a dep or a peerDep, otherwise we get errors using pnpm because it is strict about imports.