### PR TITLE
Update ember-power-select args

### DIFF
--- a/types/ember-power-select/components/power-select.d.ts
+++ b/types/ember-power-select/components/power-select.d.ts
@@ -57,12 +57,13 @@ declare module 'ember-power-select/components/power-select' {
         searchEnabled?: boolean;
         tabindex?: number | string;
         triggerComponent?: string;
+        triggerId?: string
         beforeOptionsComponent?: string;
         optionsComponent?: string;
         groupComponent?: string;
         searchPlaceholder?: string;
         loadingMessage?: string;
-        eventType: string;
+        eventType?: string;
         selectedItemComponent?: string;
         renderInPlace?: boolean;
         extra?: any;


### PR DESCRIPTION
This PR adds the `triggerId` argument and makes `eventType` optional as it defaults to "mousedown".