### PR TITLE
Add `extensions` arg to MarkdownToHtml signature

### DIFF
--- a/types/ember-cli-showdown/markdown-to-html.d.ts
+++ b/types/ember-cli-showdown/markdown-to-html.d.ts
@@ -213,6 +213,12 @@ declare module 'ember-cli-showdown/components/markdown-to-html' {
                  * @default false
                  */
                 splitAdjacentBlockquotes?: boolean;
+
+                /**
+                 * Showdowon extensions to load.
+                 * @default null
+                 */
+                extensions?: string[] | string | null;
             };
         };
     }


### PR DESCRIPTION
The MarkdownToHtml component has an [extensions](https://github.com/empress/ember-cli-showdown#showdown-extensions) arg. This change adds it to the component signature.