### PR TITLE
Add string type to transform parameter in FaIconComponentSignature

### DIFF
--- a/types/@fortawesome/ember-fontawesome/fa-icon.d.ts
+++ b/types/@fortawesome/ember-fontawesome/fa-icon.d.ts
@@ -25,7 +25,7 @@ declare module '@fortawesome/ember-fontawesome/components/fa-icon' {
             flip?: FlipProp;
             spin?: boolean;
             fixedWidth?: boolean;
-            transform?: Transform;
+            transform?: Transform | string;
             symbol?: boolean;
         };
     }


### PR DESCRIPTION
glint-template-types has types for the ember-fontawesome module.

Within ember-fontawesome the class `FaIconComponent` has an optional parameter named `transform` that is typed as `Transform` however the component also supports a `string` type for this parameter which is not currently supported by glint-template-types:

https://github.com/FortAwesome/ember-fontawesome/blob/50c5d0f93bb5d992633bad98f64e39ae52541e8e/addon/components/fa-icon.js#L91-L96

```js
    const transform = objectWithKey(
      'transform',
      typeof this.args.transform === 'string'
        ? parse.transform(this.args.transform)
        : this.args.transform
    );
```

this pr adjusts the transform parameter type to permit a string argument:

```diff
    export interface FaIconComponentSignature {
        Element: SVGElement;
        Args: {
            icon: IconName;
            prefix?: IconPrefix;
            size?: SizeProp;
            rotation?: RotateProp;
            pull?: PullProp;
            pulse?: boolean;
            border?: boolean;
            listItem?: boolean;
            flip?: FlipProp;
            spin?: boolean;
            fixedWidth?: boolean;
-           transform?: Transform;
+           transform?: Transform | string;
            symbol?: boolean;
        };
    }
```
