### PR TITLE
Allow readonly arrays for options

### DIFF
--- a/types/ember-power-select/components/power-select.d.ts
+++ b/types/ember-power-select/components/power-select.d.ts
@@ -84,7 +84,7 @@ declare module 'ember-power-select/components/power-select' {
         onInput?: (term: string, select: Select, e: Event) => string | false | void;
         onKeydown?: (select: Select, e: KeyboardEvent) => boolean | undefined;
         onOpen?: (select: Select, e: Event) => boolean | undefined;
-        options: O[] | Promise<O[]> | PromiseProxy<O[]>;
+        options: O[] | Promise<O[]> | PromiseProxy<O[]> | readonly O[];
         optionsComponent?: SafeComponentStringOrComponent;
         placeholderComponent?: SafeComponentStringOrComponent;
         placeholder?: string;


### PR DESCRIPTION
I'm not sure if this is all we need here, but I think we need something to allow `readonly` arrays too. Maybe they should always be readonly? Power select should not be mutating the options, right?