### PR TITLE
Support verbatimModuleSyntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "expect-type": "^0.13.0",
         "prettier": "^2.7.1",
         "release-it": "^14.14.2",
-        "typescript": "^4.8.4",
+        "typescript": "^5.3.2",
         "validated-changeset": "^1.3.2"
     },
     "peerDependencies": {

--- a/tests/ember-truth-helpers/and-test.ts
+++ b/tests/ember-truth-helpers/and-test.ts
@@ -2,7 +2,7 @@ import AndHelper from 'ember-truth-helpers/helpers/and';
 
 import { expectTypeOf } from 'expect-type';
 
-import { ReturnOf } from '../util';
+import type { ReturnOf } from '../util';
 
 // string could be an empty string and get returned, otherwse we get null
 declare const return1: ReturnOf<AndHelper<string, null, undefined, number | null>>;

--- a/tests/ember-truth-helpers/eq-test.ts
+++ b/tests/ember-truth-helpers/eq-test.ts
@@ -2,7 +2,7 @@ import EqHelper from 'ember-truth-helpers/helpers/eq';
 
 import { expectTypeOf } from 'expect-type';
 
-import { ReturnOf } from '../util';
+import type { ReturnOf } from '../util';
 
 declare const ret: ReturnOf<EqHelper>;
 expectTypeOf(ret).toBeBoolean();

--- a/tests/ember-truth-helpers/or-test.ts
+++ b/tests/ember-truth-helpers/or-test.ts
@@ -2,7 +2,7 @@ import OrHelper from 'ember-truth-helpers/helpers/or';
 
 import { expectTypeOf } from 'expect-type';
 
-import { ReturnOf } from '../util';
+import type { ReturnOf } from '../util';
 
 // if number is 0, we'll eventually end up on string, it may be empty but we'll get it either way
 declare const return1: ReturnOf<OrHelper<number | null, undefined, null, string>>;

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,3 +1,3 @@
-import Helper, { ExpandSignature } from '@ember/component/helper';
+import Helper, { type ExpandSignature } from '@ember/component/helper';
 
 export type ReturnOf<T> = T extends Helper<infer S> ? ExpandSignature<S>['Return'] : never;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         "baseUrl": ".",
         "module": "es6",
         "experimentalDecorators": true,
+        "verbatimModuleSyntax": true,
         "paths": {
             "@gavant/glint-template-types/*": ["*"]
         }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,5 +1,5 @@
 import { htmlSafe } from '@ember/template';
-import { ExpandSignature } from '@glimmer/component/-private/component';
+import type { ExpandSignature } from '@glimmer/component/-private/component';
 
 // WARNING: This is not guaranteed to maintain argument position if more than one args name is passed!
 export type SignatureWithPositionedArg<S, K extends keyof ExpandSignature<S>['Args']['Named']> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9886,10 +9886,10 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
+  integrity sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==
 
 ua-parser-js@^0.7.31:
   version "0.7.31"


### PR DESCRIPTION
Currently if a consuming app enables the [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) typescript compiler option and ends up (indirectly) consuming `utils/types.ts`, compiling/glinting will produce the error:

```
../node_modules/@gavant/glint-template-types/utils/types.ts:2:10 - error TS1484: 'ExpandSignature' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

2 import { ExpandSignature } from '@glimmer/component/-private/component';
```

This PR addresses this, and also makes it so that tests will catch such violations in the future.

It strikes me that it might make sense to make this package's typescript config use `@tsconfig/ember` so it more closely matches that of blueprint generated Ember apps/addons, but that's outside the scope of this PR.