### PR TITLE
Fix ember-on-helper internal types

### DIFF
--- a/types/ember-on-helper/-private/shared.d.ts
+++ b/types/ember-on-helper/-private/shared.d.ts
@@ -1,16 +1,14 @@
-declare module 'ember-on-helper/helpers/on' {
-    export interface OnArgs {
-        /** To fire an event listener only once pass true */
-        once?: boolean;
+export interface OnArgs {
+    /** To fire an event listener only once pass true */
+    once?: boolean;
 
-        /**
-         * If true, you promise to not call event.preventDefault(). This allows the browser to optimize the processing of this event and not block the UI thread. This prevent scroll jank.
-         *
-         * If you still call event.preventDefault(), an assertion will be raised.
-         */
-        passive?: boolean;
+    /**
+     * If true, you promise to not call event.preventDefault(). This allows the browser to optimize the processing of this event and not block the UI thread. This prevent scroll jank.
+     *
+     * If you still call event.preventDefault(), an assertion will be raised.
+     */
+    passive?: boolean;
 
-        /** To listen for an event during the capture phase already, use the capture option */
-        capture?: boolean;
-    }
+    /** To listen for an event during the capture phase already, use the capture option */
+    capture?: boolean;
 }

--- a/types/ember-on-helper/on-document.d.ts
+++ b/types/ember-on-helper/on-document.d.ts
@@ -1,7 +1,7 @@
 declare module 'ember-on-helper/helpers/on-document' {
     import Helper from '@ember/component/helper';
 
-    import { OnArgs } from 'ember-on-helper/helpers/on';
+    import { OnArgs } from '@gavant/glint-template-types/types/ember-on-helper/-private/shared';
 
     interface OnDocumentHelperSignature<K extends keyof DocumentEventMap> {
         Args: { Named: OnArgs; Positional: [eventName: K, handler: (event: DocumentEventMap[K]) => void] };

--- a/types/ember-on-helper/on-window.d.ts
+++ b/types/ember-on-helper/on-window.d.ts
@@ -1,7 +1,7 @@
 declare module 'ember-on-helper/helpers/on-window' {
     import Helper from '@ember/component/helper';
 
-    import { OnArgs } from 'ember-on-helper/helpers/on';
+    import { OnArgs } from '@gavant/glint-template-types/types/ember-on-helper/-private/shared';
 
     interface OnWindowHelperSignature<K extends keyof WindowEventMap> {
         Args: { Named: OnArgs; Positional: [eventName: K, handler: (event: WindowEventMap[K]) => void] };


### PR DESCRIPTION
This mirrors the same setup/structure in ember-render-modifiers and ember-truth-helpers. The current setup was inherited from 0.2.x and does not work with the currently recommend ambient type imports.