### PR TITLE
Expand peer dependency ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
         "validated-changeset": "^1.3.2"
     },
     "peerDependencies": {
-        "ember-animated": "^1.0.0",
-        "ember-basic-dropdown": "^6.0.1",
-        "ember-concurrency": "^2.0.3",
+        "ember-animated": "^1.0.0 || ^2.0.0",
+        "ember-basic-dropdown": "^6.0.1 || ^7.0.0",
+        "ember-concurrency": "^2.0.3 || ^3.1.0 || ^4.0.0",
         "ember-concurrency-async": "^1.0.0",
         "ember-concurrency-ts": "^0.3.0",
-        "ember-intl": "^5.7.2",
-        "ember-modifier": "^3.2.7",
-        "ember-power-select": "^5.0.0",
+        "ember-intl": "^5.7.2 || ^6.1.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0",
+        "ember-power-select": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
     },
     "peerDependenciesMeta": {


### PR DESCRIPTION
This should allow apps to use newer versions of these addons and avoid package manager validation errors.

I added all the versions that are currently available for the addons but I'm only currently using ember-intl from this list so hopefully all the others work as well. I followed the example in #84.

Closes #88.
