### PR TITLE
Make select optional in power select onChange

### DIFF
--- a/types/ember-power-select/components/power-select.d.ts
+++ b/types/ember-power-select/components/power-select.d.ts
@@ -78,7 +78,7 @@ declare module 'ember-power-select/components/power-select' {
         noMatchesMessage?: string;
         noMatchesMessageComponent?: SafeComponentStringOrComponent;
         onBlur?: (select: Select, event: FocusEvent) => void;
-        onChange: (selection: O, select: Select, event?: Event) => void;
+        onChange: (selection: O, select?: Select, event?: Event) => void;
         onClose?: (select: Select, e: Event) => boolean | undefined;
         onFocus?: (select: Select, event: FocusEvent) => void;
         onInput?: (term: string, select: Select, e: Event) => string | false | void;


### PR DESCRIPTION
The power select docs do not mention anything other than the selection being passed into `onChange`, so I think the rest of the args should be optional.