### PR TITLE
Support selecting an array of options in power select multiple

### DIFF
--- a/types/ember-power-select/components/power-select-multiple.d.ts
+++ b/types/ember-power-select/components/power-select-multiple.d.ts
@@ -3,7 +3,8 @@ declare module 'ember-power-select/components/power-select-multiple' {
 
     import { PowerSelectArgs, PromiseProxy, Select } from 'ember-power-select/components/power-select';
 
-    interface PowerSelectMultipleArgs<O> extends Omit<PowerSelectArgs<O>, 'selected'> {
+    interface PowerSelectMultipleArgs<O> extends Omit<PowerSelectArgs<O>, 'onChange' | 'selected'> {
+        onChange: (selection: O[], select?: Select, event?: Event) => void;
         selected?: O[] | Promise<O[]> | PromiseProxy<O[]>;
     }
     export interface PowerSelectMultipleSignature<O> {


### PR DESCRIPTION
For power select multiple, I think `onChange` should be able to support selecting an array of options, not just a single option.