### PR TITLE
Add `{{on}}` helper type definition

### DIFF
--- a/types/ember-on-helper/on.d.ts
+++ b/types/ember-on-helper/on.d.ts
@@ -1,0 +1,19 @@
+declare module 'ember-on-helper/helpers/on' {
+    import Helper from '@ember/component/helper';
+
+    import { OnArgs } from '@gavant/glint-template-types/types/ember-on-helper/-private/shared';
+
+    interface OnHelperSignature<K extends keyof GlobalEventHandlersEventMap> {
+        Args: {
+            Named: OnArgs;
+            Positional: [
+                target: EventTarget | null | undefined,
+                eventName: K,
+                handler: (event: GlobalEventHandlersEventMap[K]) => void
+            ];
+        };
+        Return: null;
+    }
+
+    export default class OnHelper<K extends keyof GlobalEventHandlersEventMap> extends Helper<OnHelperSignature<K>> {}
+}


### PR DESCRIPTION
We had `{{on-window}}` and `{{on-document}}`, but not `{{on}}`. These types could probably be improved by replacing `EventTarget` with a type argument that can be used to narrow the event map, but I didn't want to take that on right now.